### PR TITLE
update db types generation docs and bump supabase deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,51 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Environment variables
 
-This project queries Supabase **only from the server** (no browser SDK). You must supply
-two values in a `.env.local` file at the project root:
+This project queries Supabase **only from the server** (no browser SDK). The server client
+in `src/utils/supabase/server.ts` uses the **service role** key so API routes can read
+data without per-user auth. Add a `.env.local` file at the project root:
 
 ```bash
 # .env.local
-SUPABASE_PROJECT_URL="https://<your-project-id>.supabase.co"
-SUPABASE_ANON_KEY="<your-anon-key>"
+SUPABASE_PROJECT_URL="https://<project-ref>.supabase.co"
+SUPABASE_SERVICE_ROLE="<your-service-role-key>"
+# Used only by `pnpm run sb:gen` (TypeScript types from the hosted project)
+SUPABASE_PROJECT_ID="<project-ref>"
 ```
 
-For convenience we ship an `.env.example` file—copy it and fill in your credentials:
+The project ref is the same substring that appears in the dashboard URL and in your
+project URL (`https://<project-ref>.supabase.co`).
+
+Copy `env.example` to `.env.local` and fill in real values:
 
 ```bash
-cp .env.example .env.local
-# then edit .env.local and add real values
+cp env.example .env.local
 ```
 
-Run `npm run dev` afterwards and visit `/api/ping` to verify the connection.
+Run `pnpm dev` (or `npm run dev`) and visit `/api/ping` to verify the connection.
+
+## Generating TypeScript types (`src/types/database.ts`)
+
+After the database schema changes, regenerate types so `Database` stays in sync with
+PostgREST.
+
+**Prerequisites:** the `supabase` CLI is a dev dependency. You must be logged in once
+so the CLI can talk to the Supabase API (`gen types` uses your CLI session, not the
+service role key).
+
+```bash
+pnpm run sb:login   # opens the browser once; stores a token for the CLI
+pnpm run sb:gen     # requires SUPABASE_PROJECT_ID in .env.local
+```
+
+That runs `supabase gen types --lang typescript --project-id <project-ref>` and
+overwrites **`src/types/database.ts`** (the `Database` type used by
+`src/utils/supabase/server.ts`).
+
+**Without the CLI:** if you use the Supabase MCP in Cursor, the `generate_typescript_types`
+tool accepts your `project_id` and returns the same TypeScript; save that output as
+`src/types/database.ts`.
+
+Other Supabase CLI shortcuts are in `package.json` (`sb:start`, `sb:db:pull`, etc.) for
+when you adopt local Docker workflows; this repo does not ship a `supabase/` config
+directory yet, so type generation is remote-project based.

--- a/env.example
+++ b/env.example
@@ -1,2 +1,3 @@
-SUPABASE_PROJECT_URL="https://your-project.supabase.co"
-SUPABASE_ANON_KEY="your-anon-key" 
+SUPABASE_PROJECT_URL="https://your-project-ref.supabase.co"
+SUPABASE_SERVICE_ROLE="your-service-role-secret"
+SUPABASE_PROJECT_ID="your-project-ref"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/material-nextjs": "^7.3.3",
         "@mui/x-charts": "^8.16.0",
         "@next/env": "^15.5.3",
-        "@supabase/supabase-js": "^2.57.4",
+        "@supabase/supabase-js": "^2.100.1",
         "next": "15.5.9",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -30,7 +30,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.1.7",
         "eslint-plugin-import": "^2.31.0",
-        "supabase": "^2.40.7",
+        "supabase": "^2.84.4",
         "tsx": "^4.20.5",
         "typescript": "^5.7.3"
       },
@@ -211,6 +211,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
       "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -245,6 +246,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -288,6 +290,7 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1489,6 +1492,7 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@mui/material/-/material-7.3.4.tgz",
       "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.4",
@@ -1640,6 +1644,7 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@mui/system/-/system-7.3.3.tgz",
       "integrity": "sha512-Lqq3emZr5IzRLKaHPuMaLBDVaGvxoh6z7HMWd1RPKawBM5uMRaQ4ImsmmgXWtwJdfZux5eugfDhXJUo2mliS8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/private-theming": "^7.3.3",
@@ -2037,77 +2042,89 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.71.1",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/auth-js/-/auth-js-2.71.1.tgz",
-      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "version": "2.100.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/auth-js/-/auth-js-2.100.1.tgz",
+      "integrity": "sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.4.6",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/functions-js/-/functions-js-2.4.6.tgz",
-      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "version": "2.100.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/functions-js/-/functions-js-2.100.1.tgz",
+      "integrity": "sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.21.4",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
-      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "version": "2.100.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/postgrest-js/-/postgrest-js-2.100.1.tgz",
+      "integrity": "sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.15.5",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
-      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "version": "2.100.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/realtime-js/-/realtime-js-2.100.1.tgz",
+      "integrity": "sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.13",
-        "@types/phoenix": "^1.6.6",
+        "@supabase/phoenix": "^0.4.0",
         "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
         "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.12.1",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/storage-js/-/storage-js-2.12.1.tgz",
-      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "version": "2.100.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/storage-js/-/storage-js-2.100.1.tgz",
+      "integrity": "sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.57.4",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
-      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "version": "2.100.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@supabase/supabase-js/-/supabase-js-2.100.1.tgz",
+      "integrity": "sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.71.1",
-        "@supabase/functions-js": "2.4.6",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.21.4",
-        "@supabase/realtime-js": "2.15.5",
-        "@supabase/storage-js": "2.12.1"
+        "@supabase/auth-js": "2.100.1",
+        "@supabase/functions-js": "2.100.1",
+        "@supabase/postgrest-js": "2.100.1",
+        "@supabase/realtime-js": "2.100.1",
+        "@supabase/storage-js": "2.100.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -2230,12 +2247,6 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.6",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/phoenix/-/phoenix-1.6.6.tgz",
-      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
-      "license": "MIT"
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2247,6 +2258,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2315,6 +2327,7 @@
       "integrity": "sha512-Tqoa05bu+t5s8CTZFaGpCH2ub3QeT9YDkXbPd3uQ4SfsLoh1/vv2GEYAioPoxCWJJNsenXlC88tRjwoHNts1oQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.24.1",
         "@typescript-eslint/types": "8.24.1",
@@ -2521,6 +2534,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2539,9 +2553,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "version": "8.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/agent-base/-/agent-base-8.0.0.tgz",
+      "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2837,20 +2851,20 @@
       "license": "MIT"
     },
     "node_modules/bin-links": {
-      "version": "5.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/bin-links/-/bin-links-5.0.0.tgz",
-      "integrity": "sha512-sdleLVfCjBtgO5cNjA2HVRvWBJAHs4zwenaCPMNJAJU0yNxpzj80IpjOIimkpkr+mhlA+how5poQtt53PygbHA==",
+      "version": "6.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/bin-links/-/bin-links-6.0.0.tgz",
+      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "cmd-shim": "^7.0.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "read-cmd-shim": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2999,13 +3013,13 @@
       }
     },
     "node_modules/cmd-shim": {
-      "version": "7.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cmd-shim/-/cmd-shim-7.0.0.tgz",
-      "integrity": "sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==",
+      "version": "8.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/color": {
@@ -3699,6 +3713,7 @@
       "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3872,6 +3887,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -4606,17 +4622,26 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "version": "8.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+      "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -5332,19 +5357,19 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "3.0.2",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minizlib/-/minizlib-3.0.2.tgz",
-      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "version": "3.1.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5352,22 +5377,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -5406,6 +5415,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -5494,13 +5504,13 @@
       }
     },
     "node_modules/npm-normalize-package-bin": {
-      "version": "4.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
-      "integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+      "version": "5.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/object-assign": {
@@ -5825,13 +5835,13 @@
       }
     },
     "node_modules/proc-log": {
-      "version": "5.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/proc-log/-/proc-log-5.0.0.tgz",
-      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "version": "6.1.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/prop-types": {
@@ -5881,6 +5891,7 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5890,6 +5901,7 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5920,13 +5932,13 @@
       }
     },
     "node_modules/read-cmd-shim": {
-      "version": "5.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/read-cmd-shim/-/read-cmd-shim-5.0.0.tgz",
-      "integrity": "sha512-SEbJV7tohp3DAAILbEMPXavBjAnMN0tVnh4+9G8ihV4Pq3HYF9h8QNez9zkJ1ILkv9G2BjdzwctznGZXgu/HGw==",
+      "version": "6.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6532,17 +6544,17 @@
       "license": "MIT"
     },
     "node_modules/supabase": {
-      "version": "2.40.7",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/supabase/-/supabase-2.40.7.tgz",
-      "integrity": "sha512-59lNW92axdufcEUdctNQpEc4k6uTEpzIUbqVXNSdWEDS/A/2yLGLxPOQQ0OBCsaJRhrVMmYXlRwgJK2PAoVQnA==",
+      "version": "2.84.4",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/supabase/-/supabase-2.84.4.tgz",
+      "integrity": "sha512-+WSe/7FFMuEOa1LJr1tZh12WDwW6lpKSmBjiEmf7m9j/ialf2oxeUMlsJCdYpST5kQ7PN0XDyvqnjE0tv/AB2w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "bin-links": "^5.0.0",
-        "https-proxy-agent": "^7.0.2",
+        "bin-links": "^6.0.0",
+        "https-proxy-agent": "^8.0.0",
         "node-fetch": "^3.3.2",
-        "tar": "7.4.3"
+        "tar": "7.5.13"
       },
       "bin": {
         "supabase": "bin/supabase"
@@ -6587,17 +6599,16 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "version": "7.5.13",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
         "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
+        "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
       "engines": {
@@ -6642,6 +6653,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6661,12 +6673,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.0.1",
@@ -6817,6 +6823,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6877,22 +6884,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -7010,23 +7001,22 @@
       }
     },
     "node_modules/write-file-atomic": {
-      "version": "6.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
-      "integrity": "sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==",
+      "version": "7.0.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mui/material": "^7.3.4",
     "@mui/x-charts": "^8.16.0",
     "@next/env": "^15.5.3",
-    "@supabase/supabase-js": "^2.57.4",
+    "@supabase/supabase-js": "^2.100.1",
     "next": "15.5.9",
     "react-dom": "^19.1.1",
     "react": "^19.1.1"
@@ -44,7 +44,7 @@
     "eslint-config-next": "15.1.7",
     "eslint-plugin-import": "^2.31.0",
     "eslint": "^9",
-    "supabase": "^2.40.7",
+    "supabase": "^2.84.4",
     "tsx": "^4.20.5",
     "typescript": "^5.7.3"
   }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -14,6 +14,129 @@ export type Database = {
   }
   public: {
     Tables: {
+      attorney_detail_report: {
+        Row: {
+          adult_felony_cases_paid: number | null
+          adult_misdemeanor_cases_paid: number | null
+          adult_time_percent: number | null
+          attorney_name: string | null
+          bar_number: number | null
+          capital_murder_cases_paid: number | null
+          county: string | null
+          court: string | null
+          court_id: number | null
+          felony_appeals_cases_paid: number | null
+          fiscal_year: number | null
+          id: string
+          juvenile_appeals_cases_paid: number | null
+          juvenile_cases_paid: number | null
+          juvenile_time_percent: number | null
+          misdemeanor_appeals_cases_paid: number | null
+          total_cases: number | null
+          total_paid: number | null
+        }
+        Insert: {
+          adult_felony_cases_paid?: number | null
+          adult_misdemeanor_cases_paid?: number | null
+          adult_time_percent?: number | null
+          attorney_name?: string | null
+          bar_number?: number | null
+          capital_murder_cases_paid?: number | null
+          county?: string | null
+          court?: string | null
+          court_id?: number | null
+          felony_appeals_cases_paid?: number | null
+          fiscal_year?: number | null
+          id: string
+          juvenile_appeals_cases_paid?: number | null
+          juvenile_cases_paid?: number | null
+          juvenile_time_percent?: number | null
+          misdemeanor_appeals_cases_paid?: number | null
+          total_cases?: number | null
+          total_paid?: number | null
+        }
+        Update: {
+          adult_felony_cases_paid?: number | null
+          adult_misdemeanor_cases_paid?: number | null
+          adult_time_percent?: number | null
+          attorney_name?: string | null
+          bar_number?: number | null
+          capital_murder_cases_paid?: number | null
+          county?: string | null
+          court?: string | null
+          court_id?: number | null
+          felony_appeals_cases_paid?: number | null
+          fiscal_year?: number | null
+          id?: string
+          juvenile_appeals_cases_paid?: number | null
+          juvenile_cases_paid?: number | null
+          juvenile_time_percent?: number | null
+          misdemeanor_appeals_cases_paid?: number | null
+          total_cases?: number | null
+          total_paid?: number | null
+        }
+        Relationships: []
+      }
+      attorney_detail_report_raw: {
+        Row: {
+          "Adult Felony Cases Paid": string | null
+          "Adult Misdemeanor Cases Paid": string | null
+          "Adult Time Percent": string | null
+          "Attorney Name": string | null
+          "Bar #": number | null
+          "Capital Murder Cases Paid": string | null
+          County: string | null
+          Court: string | null
+          "Court ID": number | null
+          "Felony Appeals Cases Paid": string | null
+          "FY Reported": number | null
+          "Juvenile Appeals Cases Paid": string | null
+          "Juvenile Cases Paid": string | null
+          "Juvenile Time Percent": string | null
+          "Misdemeanor Appeals Cases Paid": string | null
+          "Total Cases": string | null
+          "Total Paid": string | null
+        }
+        Insert: {
+          "Adult Felony Cases Paid"?: string | null
+          "Adult Misdemeanor Cases Paid"?: string | null
+          "Adult Time Percent"?: string | null
+          "Attorney Name"?: string | null
+          "Bar #"?: number | null
+          "Capital Murder Cases Paid"?: string | null
+          County?: string | null
+          Court?: string | null
+          "Court ID"?: number | null
+          "Felony Appeals Cases Paid"?: string | null
+          "FY Reported"?: number | null
+          "Juvenile Appeals Cases Paid"?: string | null
+          "Juvenile Cases Paid"?: string | null
+          "Juvenile Time Percent"?: string | null
+          "Misdemeanor Appeals Cases Paid"?: string | null
+          "Total Cases"?: string | null
+          "Total Paid"?: string | null
+        }
+        Update: {
+          "Adult Felony Cases Paid"?: string | null
+          "Adult Misdemeanor Cases Paid"?: string | null
+          "Adult Time Percent"?: string | null
+          "Attorney Name"?: string | null
+          "Bar #"?: number | null
+          "Capital Murder Cases Paid"?: string | null
+          County?: string | null
+          Court?: string | null
+          "Court ID"?: number | null
+          "Felony Appeals Cases Paid"?: string | null
+          "FY Reported"?: number | null
+          "Juvenile Appeals Cases Paid"?: string | null
+          "Juvenile Cases Paid"?: string | null
+          "Juvenile Time Percent"?: string | null
+          "Misdemeanor Appeals Cases Paid"?: string | null
+          "Total Cases"?: string | null
+          "Total Paid"?: string | null
+        }
+        Relationships: []
+      }
       casemetadata: {
         Row: {
           case_name: string | null
@@ -125,7 +248,216 @@ export type Database = {
             foreignKeyName: "charge_case_id_fkey"
             columns: ["case_id"]
             isOneToOne: false
+            referencedRelation: "all_taylor_data"
+            referencedColumns: ["casemetadata_id"]
+          },
+          {
+            foreignKeyName: "charge_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
             referencedRelation: "casemetadata"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "charge_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
+            referencedRelation: "latest_case_all_things_taylor"
+            referencedColumns: ["casemetadata_id"]
+          },
+        ]
+      }
+      counties: {
+        Row: {
+          created_at: string | null
+          fips_code: string | null
+          id: number
+          name: string
+          population: number | null
+          region: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          fips_code?: string | null
+          id: number
+          name: string
+          population?: number | null
+          region?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          fips_code?: string | null
+          id?: number
+          name?: string
+          population?: number | null
+          region?: string | null
+        }
+        Relationships: []
+      }
+      counties_managed_systems: {
+        Row: {
+          area_sq_miles: number | null
+          case_type_appeal: boolean | null
+          case_type_capital: boolean | null
+          case_type_felony: boolean | null
+          case_type_felony_mh: boolean | null
+          case_type_juvenile: boolean | null
+          case_type_misdemeanor: boolean | null
+          case_type_misdemeanor_mh: boolean | null
+          case_type_other: boolean | null
+          county: string | null
+          county_seat: string | null
+          created_at: string
+          id: number
+          name: string | null
+          population: number | null
+          system_type: string | null
+        }
+        Insert: {
+          area_sq_miles?: number | null
+          case_type_appeal?: boolean | null
+          case_type_capital?: boolean | null
+          case_type_felony?: boolean | null
+          case_type_felony_mh?: boolean | null
+          case_type_juvenile?: boolean | null
+          case_type_misdemeanor?: boolean | null
+          case_type_misdemeanor_mh?: boolean | null
+          case_type_other?: boolean | null
+          county?: string | null
+          county_seat?: string | null
+          created_at?: string
+          id?: number
+          name?: string | null
+          population?: number | null
+          system_type?: string | null
+        }
+        Update: {
+          area_sq_miles?: number | null
+          case_type_appeal?: boolean | null
+          case_type_capital?: boolean | null
+          case_type_felony?: boolean | null
+          case_type_felony_mh?: boolean | null
+          case_type_juvenile?: boolean | null
+          case_type_misdemeanor?: boolean | null
+          case_type_misdemeanor_mh?: boolean | null
+          case_type_other?: boolean | null
+          county?: string | null
+          county_seat?: string | null
+          created_at?: string
+          id?: number
+          name?: string | null
+          population?: number | null
+          system_type?: string | null
+        }
+        Relationships: []
+      }
+      court_activity: {
+        Row: {
+          county_id: number
+          court_type: string
+          document_id: string
+          id: string
+          measure_detail: string
+          measure_group: string | null
+          measure_type: string
+          month: number
+          offense_type: string
+          position: string | null
+          value: number | null
+          year: number
+        }
+        Insert: {
+          county_id: number
+          court_type: string
+          document_id: string
+          id?: string
+          measure_detail: string
+          measure_group?: string | null
+          measure_type: string
+          month: number
+          offense_type: string
+          position?: string | null
+          value?: number | null
+          year: number
+        }
+        Update: {
+          county_id?: number
+          court_type?: string
+          document_id?: string
+          id?: string
+          measure_detail?: string
+          measure_group?: string | null
+          measure_type?: string
+          month?: number
+          offense_type?: string
+          position?: string | null
+          value?: number | null
+          year?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "court_activity_county_id_fkey"
+            columns: ["county_id"]
+            isOneToOne: false
+            referencedRelation: "counties"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "court_activity_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      court_summary: {
+        Row: {
+          county_id: number
+          court_type: string
+          document_id: string
+          id: string
+          measure_detail: string
+          measure_type: string
+          month: number
+          value: number | null
+          year: number
+        }
+        Insert: {
+          county_id: number
+          court_type: string
+          document_id: string
+          id?: string
+          measure_detail: string
+          measure_type: string
+          month: number
+          value?: number | null
+          year: number
+        }
+        Update: {
+          county_id?: number
+          court_type?: string
+          document_id?: string
+          id?: string
+          measure_detail?: string
+          measure_type?: string
+          month?: number
+          value?: number | null
+          year?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "court_summary_county_id_fkey"
+            columns: ["county_id"]
+            isOneToOne: false
+            referencedRelation: "counties"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "court_summary_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "documents"
             referencedColumns: ["id"]
           },
         ]
@@ -172,8 +504,22 @@ export type Database = {
             foreignKeyName: "defendant_case_id_fkey"
             columns: ["case_id"]
             isOneToOne: true
+            referencedRelation: "all_taylor_data"
+            referencedColumns: ["casemetadata_id"]
+          },
+          {
+            foreignKeyName: "defendant_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: true
             referencedRelation: "casemetadata"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "defendant_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: true
+            referencedRelation: "latest_case_all_things_taylor"
+            referencedColumns: ["casemetadata_id"]
           },
         ]
       }
@@ -207,8 +553,22 @@ export type Database = {
             foreignKeyName: "defenseattorney_case_id_fkey"
             columns: ["case_id"]
             isOneToOne: false
+            referencedRelation: "all_taylor_data"
+            referencedColumns: ["casemetadata_id"]
+          },
+          {
+            foreignKeyName: "defenseattorney_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
             referencedRelation: "casemetadata"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "defenseattorney_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
+            referencedRelation: "latest_case_all_things_taylor"
+            referencedColumns: ["casemetadata_id"]
           },
         ]
       }
@@ -239,8 +599,22 @@ export type Database = {
             foreignKeyName: "disposition_case_id_fkey"
             columns: ["case_id"]
             isOneToOne: false
+            referencedRelation: "all_taylor_data"
+            referencedColumns: ["casemetadata_id"]
+          },
+          {
+            foreignKeyName: "disposition_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
             referencedRelation: "casemetadata"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "disposition_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
+            referencedRelation: "latest_case_all_things_taylor"
+            referencedColumns: ["casemetadata_id"]
           },
         ]
       }
@@ -268,7 +642,62 @@ export type Database = {
             foreignKeyName: "dispositiondetail_disposition_id_fkey"
             columns: ["disposition_id"]
             isOneToOne: false
+            referencedRelation: "all_taylor_data"
+            referencedColumns: ["disposition_row_id"]
+          },
+          {
+            foreignKeyName: "dispositiondetail_disposition_id_fkey"
+            columns: ["disposition_id"]
+            isOneToOne: false
             referencedRelation: "disposition"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "dispositiondetail_disposition_id_fkey"
+            columns: ["disposition_id"]
+            isOneToOne: false
+            referencedRelation: "latest_case_all_things_taylor"
+            referencedColumns: ["disposition_row_id"]
+          },
+        ]
+      }
+      documents: {
+        Row: {
+          county_id: number
+          court_type: string
+          file_path: string
+          id: string
+          month: number
+          parsed_at: string | null
+          parser_version: string
+          year: number
+        }
+        Insert: {
+          county_id: number
+          court_type: string
+          file_path: string
+          id?: string
+          month: number
+          parsed_at?: string | null
+          parser_version: string
+          year: number
+        }
+        Update: {
+          county_id?: number
+          court_type?: string
+          file_path?: string
+          id?: string
+          month?: number
+          parsed_at?: string | null
+          parser_version?: string
+          year?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "documents_county_id_fkey"
+            columns: ["county_id"]
+            isOneToOne: false
+            referencedRelation: "counties"
             referencedColumns: ["id"]
           },
         ]
@@ -300,10 +729,102 @@ export type Database = {
             foreignKeyName: "event_case_id_fkey"
             columns: ["case_id"]
             isOneToOne: false
+            referencedRelation: "all_taylor_data"
+            referencedColumns: ["casemetadata_id"]
+          },
+          {
+            foreignKeyName: "event_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
             referencedRelation: "casemetadata"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "event_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
+            referencedRelation: "latest_case_all_things_taylor"
+            referencedColumns: ["casemetadata_id"]
+          },
         ]
+      }
+      indigent_defense_expenditure_data_dollars: {
+        Row: {
+          "2022_Population_Estimate": number | null
+          Adult_Capital_Murder_Felony_Count_of_Filed_Cases: number | null
+          Adult_Misdemeanor_Count_of_Filed_Cases: number | null
+          "Adult_Non-Capital_Felony_Count_of_Filed_Cases": number | null
+          Count_of_Cases_Paid_with_No_Court_Identified: number | null
+          County: string | null
+          County_Administrative_Costs: number | null
+          created_at: string
+          Direct_Client_Service_Expenditures: number | null
+          Felony_Charges_Disposed: number | null
+          Gross_Indigent_Defense_Costs: number | null
+          id: number
+          Juvenile_Charges_Disposed: number | null
+          Juvenile_Count_of_Filed_Cases: number | null
+          Misdemeanor_Charges_Disposed: number | null
+          No_of_Courts_Reporting_Expenditures: number | null
+          Received_from_Participating_Counties_in_Regional_Program:
+            | number
+            | null
+          Reimbursements_from_Defendants: number | null
+          Total_Count_of_Indigent_Defense_Cases: number | null
+          Total_Funds_Disbursed: number | null
+          Year: number | null
+        }
+        Insert: {
+          "2022_Population_Estimate"?: number | null
+          Adult_Capital_Murder_Felony_Count_of_Filed_Cases?: number | null
+          Adult_Misdemeanor_Count_of_Filed_Cases?: number | null
+          "Adult_Non-Capital_Felony_Count_of_Filed_Cases"?: number | null
+          Count_of_Cases_Paid_with_No_Court_Identified?: number | null
+          County?: string | null
+          County_Administrative_Costs?: number | null
+          created_at?: string
+          Direct_Client_Service_Expenditures?: number | null
+          Felony_Charges_Disposed?: number | null
+          Gross_Indigent_Defense_Costs?: number | null
+          id?: number
+          Juvenile_Charges_Disposed?: number | null
+          Juvenile_Count_of_Filed_Cases?: number | null
+          Misdemeanor_Charges_Disposed?: number | null
+          No_of_Courts_Reporting_Expenditures?: number | null
+          Received_from_Participating_Counties_in_Regional_Program?:
+            | number
+            | null
+          Reimbursements_from_Defendants?: number | null
+          Total_Count_of_Indigent_Defense_Cases?: number | null
+          Total_Funds_Disbursed?: number | null
+          Year?: number | null
+        }
+        Update: {
+          "2022_Population_Estimate"?: number | null
+          Adult_Capital_Murder_Felony_Count_of_Filed_Cases?: number | null
+          Adult_Misdemeanor_Count_of_Filed_Cases?: number | null
+          "Adult_Non-Capital_Felony_Count_of_Filed_Cases"?: number | null
+          Count_of_Cases_Paid_with_No_Court_Identified?: number | null
+          County?: string | null
+          County_Administrative_Costs?: number | null
+          created_at?: string
+          Direct_Client_Service_Expenditures?: number | null
+          Felony_Charges_Disposed?: number | null
+          Gross_Indigent_Defense_Costs?: number | null
+          id?: number
+          Juvenile_Charges_Disposed?: number | null
+          Juvenile_Count_of_Filed_Cases?: number | null
+          Misdemeanor_Charges_Disposed?: number | null
+          No_of_Courts_Reporting_Expenditures?: number | null
+          Received_from_Participating_Counties_in_Regional_Program?:
+            | number
+            | null
+          Reimbursements_from_Defendants?: number | null
+          Total_Count_of_Indigent_Defense_Cases?: number | null
+          Total_Funds_Disbursed?: number | null
+          Year?: number | null
+        }
+        Relationships: []
       }
       relatedcase: {
         Row: {
@@ -326,8 +847,22 @@ export type Database = {
             foreignKeyName: "relatedcase_case_id_fkey"
             columns: ["case_id"]
             isOneToOne: false
+            referencedRelation: "all_taylor_data"
+            referencedColumns: ["casemetadata_id"]
+          },
+          {
+            foreignKeyName: "relatedcase_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
             referencedRelation: "casemetadata"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relatedcase_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: false
+            referencedRelation: "latest_case_all_things_taylor"
+            referencedColumns: ["casemetadata_id"]
           },
         ]
       }
@@ -394,13 +929,272 @@ export type Database = {
             foreignKeyName: "stateinformation_case_id_fkey"
             columns: ["case_id"]
             isOneToOne: true
+            referencedRelation: "all_taylor_data"
+            referencedColumns: ["casemetadata_id"]
+          },
+          {
+            foreignKeyName: "stateinformation_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: true
             referencedRelation: "casemetadata"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "stateinformation_case_id_fkey"
+            columns: ["case_id"]
+            isOneToOne: true
+            referencedRelation: "latest_case_all_things_taylor"
+            referencedColumns: ["casemetadata_id"]
           },
         ]
       }
     }
     Views: {
+      all_taylor_data: {
+        Row: {
+          appointed_retained: string | null
+          attorney_hash: string | null
+          case_key: string | null
+          case_name: string | null
+          case_type: string | null
+          casemetadata_id: number | null
+          charge_date: string | null
+          charge_desc: string | null
+          charge_id: number | null
+          charge_level: string | null
+          charge_name: string | null
+          charge_row_id: number | null
+          county_of_jurisdiction: string | null
+          court_case_number: string | null
+          court_case_number_hashed: string | null
+          date_filed: string | null
+          defendant_address: string | null
+          defendant_date_of_birth: string | null
+          defendant_height: string | null
+          defendant_id: number | null
+          defendant_name: string | null
+          defendant_race: string | null
+          defendant_sex: string | null
+          defendant_sid: string | null
+          defendant_weight: string | null
+          defenseattorney_name: string | null
+          defenseattorney_phone: string | null
+          defenseattorney_row_id: number | null
+          dismissed_charges_count: number | null
+          disposition_date: string | null
+          disposition_event: string | null
+          disposition_row_id: number | null
+          dispositiondetail_charge: string | null
+          dispositiondetail_outcome: string | null
+          dispositiondetail_row_id: number | null
+          event_date: string | null
+          event_details: string | null
+          event_name: string | null
+          event_row_id: number | null
+          good_motions: string | null
+          has_evidence_of_representation: boolean | null
+          html_hash: string | null
+          is_primary_charge: boolean | null
+          judicial_officer: string | null
+          location: string | null
+          odyssey_id: string | null
+          offense_category_desc: string | null
+          offense_type_desc: string | null
+          original_charge: string | null
+          parsing_date: string | null
+          prosecuting_attorney: string | null
+          prosecuting_attorney_phone: string | null
+          related_case: string | null
+          relatedcase_row_id: number | null
+          stateinformation_id: number | null
+          statute: string | null
+          top_charge_level: string | null
+          top_charge_name: string | null
+          uccs_code: string | null
+          version: number | null
+        }
+        Relationships: []
+      }
+      annual_caseload: {
+        Row: {
+          annual_added: number | null
+          annual_disposed: number | null
+          county: string | null
+          county_id: number | null
+          court_type: string | null
+          dec_pending: number | null
+          jan_pending: number | null
+          year: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "court_activity_county_id_fkey"
+            columns: ["county_id"]
+            isOneToOne: false
+            referencedRelation: "counties"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      court_activity_named: {
+        Row: {
+          county: string | null
+          county_id: number | null
+          court_type: string | null
+          id: string | null
+          measure_detail: string | null
+          measure_group: string | null
+          measure_type: string | null
+          month: number | null
+          offense_type: string | null
+          position: string | null
+          value: number | null
+          year: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "court_activity_county_id_fkey"
+            columns: ["county_id"]
+            isOneToOne: false
+            referencedRelation: "counties"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      court_summary_named: {
+        Row: {
+          county: string | null
+          county_id: number | null
+          court_type: string | null
+          id: string | null
+          measure_detail: string | null
+          measure_type: string | null
+          month: number | null
+          value: number | null
+          year: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "court_summary_county_id_fkey"
+            columns: ["county_id"]
+            isOneToOne: false
+            referencedRelation: "counties"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      disposition_breakdown: {
+        Row: {
+          acquittals: number | null
+          convictions: number | null
+          county: string | null
+          county_id: number | null
+          court_type: string | null
+          deferred: number | null
+          dismissals: number | null
+          month: number | null
+          mtr_granted: number | null
+          total_disposed: number | null
+          year: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "court_activity_county_id_fkey"
+            columns: ["county_id"]
+            isOneToOne: false
+            referencedRelation: "counties"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      latest_case_all_things_taylor: {
+        Row: {
+          appointed_retained: string | null
+          attorney_hash: string | null
+          case_key: string | null
+          case_name: string | null
+          case_type: string | null
+          casemetadata_id: number | null
+          charge_date: string | null
+          charge_desc: string | null
+          charge_id: number | null
+          charge_level: string | null
+          charge_name: string | null
+          charge_row_id: number | null
+          county_of_jurisdiction: string | null
+          court_case_number: string | null
+          court_case_number_hashed: string | null
+          date_filed: string | null
+          defendant_address: string | null
+          defendant_date_of_birth: string | null
+          defendant_height: string | null
+          defendant_id: number | null
+          defendant_name: string | null
+          defendant_race: string | null
+          defendant_sex: string | null
+          defendant_sid: string | null
+          defendant_weight: string | null
+          defenseattorney_name: string | null
+          defenseattorney_phone: string | null
+          defenseattorney_row_id: number | null
+          dismissed_charges_count: number | null
+          disposition_date: string | null
+          disposition_event: string | null
+          disposition_row_id: number | null
+          dispositiondetail_charge: string | null
+          dispositiondetail_outcome: string | null
+          dispositiondetail_row_id: number | null
+          event_date: string | null
+          event_details: string | null
+          event_name: string | null
+          event_row_id: number | null
+          good_motions: string | null
+          has_evidence_of_representation: boolean | null
+          html_hash: string | null
+          is_primary_charge: boolean | null
+          judicial_officer: string | null
+          location: string | null
+          odyssey_id: string | null
+          offense_category_desc: string | null
+          offense_type_desc: string | null
+          original_charge: string | null
+          parsing_date: string | null
+          prosecuting_attorney: string | null
+          prosecuting_attorney_phone: string | null
+          related_case: string | null
+          relatedcase_row_id: number | null
+          stateinformation_id: number | null
+          statute: string | null
+          top_charge_level: string | null
+          top_charge_name: string | null
+          uccs_code: string | null
+          version: number | null
+        }
+        Relationships: []
+      }
+      monthly_caseload: {
+        Row: {
+          cases_added: number | null
+          cases_disposed: number | null
+          county: string | null
+          county_id: number | null
+          court_type: string | null
+          month: number | null
+          pending_end: number | null
+          pending_start: number | null
+          placed_inactive: number | null
+          year: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "court_activity_county_id_fkey"
+            columns: ["county_id"]
+            isOneToOne: false
+            referencedRelation: "counties"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       v_hays_attorney_caseload: {
         Row: {
           attorney_hash: string | null
@@ -429,10 +1223,7 @@ export type Database = {
         Args: { schema_name?: string }
         Returns: undefined
       }
-      try_parse_date: {
-        Args: { d: string }
-        Returns: string
-      }
+      try_parse_date: { Args: { d: string }; Returns: string }
     }
     Enums: {
       [_ in never]: never

--- a/src/utils/supabase/genTypes.ts
+++ b/src/utils/supabase/genTypes.ts
@@ -1,28 +1,18 @@
 import { execSync } from "node:child_process";
 import { loadEnvConfig } from "@next/env";
 import path from "node:path";
-import { existsSync, mkdirSync } from "node:fs";
-
-const projectDir = process.cwd();
-loadEnvConfig(projectDir);
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 
 /**
- * This script generates the types for the Supabase database.
+ * Generates `src/types/database.ts` via the Supabase CLI against the hosted project.
  *
- * Requirements:
- * 1. The supabase project to be created and the .env.local file to be present in the root of the project.
- *    - The supabase project should be created in the supabase dashboard.
- *    - You'll need the following environment variables:
- *      - SUPABASE_PROJECT_ID
- *      - SUPABASE_PROJECT_URL
- *      - SUPABASE_SERVICE_ROLE
- *      - SUPABASE_SERVICE_ROLE
+ * Requires:
+ * - `SUPABASE_PROJECT_ID` in `.env.local` (project ref from the dashboard URL).
+ * - Supabase CLI installed (devDependency) and authenticated: `pnpm run sb:login`.
  *
- * 2. Run the script:
- *    - npm run sb:gen
+ * Run: `pnpm run sb:gen`
  *
- * 3. The types will be generated in the src/types/database.ts file.
- *
+ * Note: `supabase gen types` uses the CLI login session, not API keys from env.
  */
 function main() {
   const projectDir = process.cwd();
@@ -38,16 +28,22 @@ function main() {
 
   const projectId = process.env.SUPABASE_PROJECT_ID;
 
-  console.log("projectId: ", projectId);
   if (!projectId) {
     throw new Error("SUPABASE_PROJECT_ID is not set");
   }
 
-  // This requires the supabase CLI to be installed and logged in
-  // Use proper quoting for the file path to handle spaces and special characters
-  const cmd = `supabase gen types --lang typescript --project-id ${projectId} > "${targetFile}"`;
-  console.log(cmd);
-  execSync(cmd);
+  if (!/^[a-z\d-]+$/i.test(projectId)) {
+    throw new Error("SUPABASE_PROJECT_ID has unexpected characters");
+  }
+
+  const types = execSync(
+    `supabase gen types --lang typescript --project-id ${projectId}`,
+    { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
+  );
+
+  writeFileSync(targetFile, types, "utf8");
+
+  console.log(`Wrote ${targetFile}`);
 }
 
 main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
-    },
-    "baseUrl": "."
+      "@/*": ["./src/*"],
+      "*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Updates the instructions for re-generating TypeScript types for the Supabase schema.

Bump `supabase` (CLI) and `supabase-js` to latest versions.